### PR TITLE
Add Illustrious model detection variables and options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,6 @@ The variable can be one set with the `set` or `add` commands or you can use inte
 * `_is_illustrious`: true if the loaded model version is SDXL and an Illustrious model (based on its filename). Note that for an Illustrious model `_is_sdxl` will also be true.
 * `_is_sdxl_no_illustrious`: true if the loaded model version is SDXL and not an Illustrious model.
 * `_is_sdxl_no_pony_no_illustrious`: true if the loaded model version is SDXL and not a pony model and not an Illustrious model.
-* `_is_both_pony_and_illustrious`: true if the loaded model version is detected as both a pony and Illustrious model. Only for detecting false lables. 
 * `_is_sd3`: true if the loaded model version is SD 3.x
 * `_is_flux`: true if the loaded model is Flux
 * `_is_auraflow`: true if the loaded model is AuraFlow

--- a/README.md
+++ b/README.md
@@ -271,11 +271,15 @@ The variable can be one set with the `set` or `add` commands or you can use inte
 * `_is_sd`: true if the loaded model version is any version of SD
 * `_is_sd1`: true if the loaded model version is SD 1.x
 * `_is_sd2`: true if the loaded model version is SD 2.x
-* `_is_sdxl`: true if the loaded model version is SDXL (includes Pony models)
+* `_is_sdxl`: true if the loaded model version is SDXL (includes Pony and Illustrious models)
 * `_is_ssd`: true if the loaded model version is SSD (Segmind Stable Diffusion 1B). Note that for an SSD model `_is_sdxl` will also be true.
 * `_is_sdxl_no_ssd`: true if the loaded model version is SDXL and not an SSD model.
 * `_is_pony`: true if the loaded model version is SDXL and a Pony model (based on its filename). Note that for a pony model `_is_sdxl` will also be true.
 * `_is_sdxl_no_pony`: true if the loaded model version is SDXL and not a Pony model.
+* `_is_illustrious`: true if the loaded model version is SDXL and an Illustrious model (based on its filename). Note that for an Illustrious model `_is_sdxl` will also be true.
+* `_is_sdxl_no_illustrious`: true if the loaded model version is SDXL and not an Illustrious model.
+* `_is_sdxl_no_pony_no_illustrious`: true if the loaded model version is SDXL and not a pony model and not an Illustrious model.
+* `_is_both_pony_and_illustrious`: true if the loaded model version is detected as both a pony and Illustrious model. Only for detecting false lables. 
 * `_is_sd3`: true if the loaded model version is SD 3.x
 * `_is_flux`: true if the loaded model is Flux
 * `_is_auraflow`: true if the loaded model is AuraFlow
@@ -289,6 +293,7 @@ Any `elif`s (there can be multiple) and the `else` are optional.
 ```text
 <ppp:if _is_sd1><lora:test_sd1> test sd1x
 <ppp:elif _sd_pony><lora:test_pony> test pony
+<ppp:elif _sd_illustrious><lora:test_illustrious> test illustrious
 <ppp:elif _sd_sdxl><lora:test_sdxl> test sdxl
 <ppp:else>unknown model
 <ppp:/if>
@@ -369,7 +374,7 @@ This should still work as intended, and the only negative point i see is the unn
 ### ComfyUI specific inputs
 
 * **model**: Connect here the MODEL or a string with the model class name used by ComfyUI. Needed for the model kind system variables.
-* **modelname**: Name of the model. Needed for the model name system variables and detection of pony (this also requieres for the model to be SDXL).
+* **modelname**: Name of the model. Needed for the model name system variables and detection of pony and illustrious (this also requieres for the model to be SDXL).
 * **seed**: Connect here the seed used. By default it is -1 (random).
 * **pos_prompt**: Connect here the prompt text, or fill it as a widget.
 * **neg_prompt**: Connect here the negative prompt text, or fill it as a widget.
@@ -378,6 +383,7 @@ This should still work as intended, and the only negative point i see is the unn
 
 * **Debug level**: what to write to the console. Note: in SD.Next debug messages only show if you launch it with the --debug argument.
 * **Pony substrings**: list of substrings to detect a Pony model.
+* **Illustrious substrings**: list of substrings to detect an Illustrious model.
 * **Apply in img2img**: check if you want to do the processing in img2img processes (does not apply to ComfyUI node).
 
 ### Wildcard settings

--- a/ppp.py
+++ b/ppp.py
@@ -53,6 +53,7 @@ class PromptPostProcessor:  # pylint: disable=too-few-public-methods,too-many-in
 
     DEFAULT_STN_SEPARATOR = ", "
     DEFAULT_PONY_SUBSTRINGS = ",".join(["pony", "pny", "pdxl"])
+    DEFAULT_ILLUSTRIOUS_SUBSTRINGS = ",".join(["Illustrious", "illust", "ilust", "noob"])
     DEFAULT_CHOICE_SEPARATOR = ", "
     WILDCARD_WARNING = '(WARNING TEXT "INVALID WILDCARD" IN BRIGHT RED:1.5)\nBREAK '
     WILDCARD_STOP = "INVALID WILDCARD! {0}\nBREAK "
@@ -89,6 +90,9 @@ class PromptPostProcessor:  # pylint: disable=too-few-public-methods,too-many-in
         self.debug_level = DEBUG_LEVEL(options.get("debug_level", DEBUG_LEVEL.none.value))
         self.pony_substrings = list(
             x.strip() for x in (str(options.get("pony_substrings", self.DEFAULT_PONY_SUBSTRINGS))).split(",")
+        )
+        self.illustrious_substrings = list(
+            x.strip() for x in (str(options.get("illustrious_substrings", self.DEFAULT_ILLUSTRIOUS_SUBSTRINGS))).split(",")
         )
         # Wildcards options
         self.wil_process_wildcards = options.get("process_wildcards", True)
@@ -192,6 +196,7 @@ class PromptPostProcessor:  # pylint: disable=too-few-public-methods,too-many-in
         self.system_variables["_sd"] = self.system_variables["_model"]  # deprecated
         model_filename = self.env_info.get("model_filename", "")
         is_pony = any(s in model_filename.lower() for s in self.pony_substrings)
+        is_illustrious = any(s in model_filename.lower() for s in self.illustrious_substrings)
         is_ssd = self.env_info.get("is_ssd", False)
         self.system_variables["_sdfullname"] = model_filename  # deprecated
         self.system_variables["_modelfullname"] = model_filename
@@ -205,6 +210,10 @@ class PromptPostProcessor:  # pylint: disable=too-few-public-methods,too-many-in
         self.system_variables["_is_sdxl_no_ssd"] = sdchecks["sdxl"] and not is_ssd
         self.system_variables["_is_pony"] = sdchecks["sdxl"] and is_pony
         self.system_variables["_is_sdxl_no_pony"] = sdchecks["sdxl"] and not is_pony
+        self.system_variables["_is_illustrious"] = sdchecks["sdxl"] and is_illustrious
+        self.system_variables["_is_sdxl_no_illustrious"] = sdchecks["sdxl"] and not is_illustrious
+        self.system_variables["_is_sdxl_no_pony_no_illustrious"] = sdchecks["sdxl"] and not is_pony and not is_illustrious
+        self.system_variables["_is_both_pony_and_illustrious"] = sdchecks["sdxl"] and is_pony and is_illustrious
         self.system_variables["_is_sd3"] = sdchecks["sd3"]
         self.system_variables["_is_sd"] = sdchecks["sd1"] or sdchecks["sd2"] or sdchecks["sdxl"] or sdchecks["sd3"]
         self.system_variables["_is_flux"] = sdchecks["flux"]

--- a/ppp.py
+++ b/ppp.py
@@ -213,7 +213,10 @@ class PromptPostProcessor:  # pylint: disable=too-few-public-methods,too-many-in
         self.system_variables["_is_illustrious"] = sdchecks["sdxl"] and is_illustrious
         self.system_variables["_is_sdxl_no_illustrious"] = sdchecks["sdxl"] and not is_illustrious
         self.system_variables["_is_sdxl_no_pony_no_illustrious"] = sdchecks["sdxl"] and not is_pony and not is_illustrious
-        self.system_variables["_is_both_pony_and_illustrious"] = sdchecks["sdxl"] and is_pony and is_illustrious
+        if sdchecks["sdxl"] and is_pony and is_illustrious:
+            self.logger.warning(
+                f"""SDXL Model matched both Pony and Illustrious substrings. Change the substrings in Settings -> Promp Post-Processor or rename the model file/path. ({model_filename}) """
+            )
         self.system_variables["_is_sd3"] = sdchecks["sd3"]
         self.system_variables["_is_sd"] = sdchecks["sd1"] or sdchecks["sd2"] or sdchecks["sdxl"] or sdchecks["sd3"]
         self.system_variables["_is_flux"] = sdchecks["flux"]

--- a/ppp_comfyui.py
+++ b/ppp_comfyui.py
@@ -105,6 +105,16 @@ class PromptPostProcessorComfyUINode:
                         "forceInput": False,
                     },
                 ),
+                "illustrious_substrings": (
+                    "STRING",
+                    {
+                        "default": PromptPostProcessor.DEFAULT_ILLUSTRIOUS_SUBSTRINGS,
+                        "placeholder": "comma separated list",
+                        "tooltip": "Comma separated list of substrings to look for in the modelname to determine if the model is an illustrious model",
+                        "defaultInput": False,
+                        "forceInput": False,
+                    },
+                ),
                 "wc_process_wildcards": (
                     "BOOLEAN",
                     {
@@ -334,6 +344,7 @@ class PromptPostProcessorComfyUINode:
         seed,
         debug_level,  # pylint: disable=unused-argument
         pony_substrings,
+        illustrious_substrings,
         wc_process_wildcards,
         wc_wildcards_folders,
         wc_if_wildcards,
@@ -362,6 +373,7 @@ class PromptPostProcessorComfyUINode:
             "neg_prompt": neg_prompt,
             "seed": seed,
             "pony_substrings": pony_substrings,
+            "illustrious_substrings": illustrious_substrings,
             "process_wildcards": wc_process_wildcards,
             "wildcards_folders": wc_wildcards_folders,
             "if_wildcards": wc_if_wildcards,
@@ -393,6 +405,7 @@ class PromptPostProcessorComfyUINode:
         seed,
         debug_level,
         pony_substrings,
+        illustrious_substrings,
         wc_process_wildcards,
         wc_wildcards_folders,
         wc_if_wildcards,
@@ -449,6 +462,7 @@ class PromptPostProcessorComfyUINode:
         options = {
             "debug_level": debug_level,
             "pony_substrings": pony_substrings,
+            "illustrious_substrings": illustrious_substrings,
             "process_wildcards": wc_process_wildcards,
             "if_wildcards": wc_if_wildcards,
             "choice_separator": wc_choice_separator,

--- a/scripts/ppp_script.py
+++ b/scripts/ppp_script.py
@@ -181,7 +181,7 @@ class PromptPostProcessorA1111Script(scripts.Script):
             env_info["is_sdxl"] = getattr(p.sd_model, "is_sdxl", False)
             env_info["is_ssd"] = False  # ?
             env_info["is_sd3"] = getattr(p.sd_model, "is_sd3", False)
-            env_info["is_flux"] = p.sd_model.model_config.__class__.__name__ == "Flux"
+            env_info["is_flux"] = "Flux" in p.sd_model.model_config.__class__.__name__
             env_info["is_auraflow"] = False  # p.sd_model.model_config.__class__.__name__ == "AuraFlow"
         else:  # assume A1111 compatible (p.sd_model.__class__.__name__=="DiffusionEngine")
             env_info["model_class"] = p.sd_model.__class__.__name__

--- a/scripts/ppp_script.py
+++ b/scripts/ppp_script.py
@@ -203,6 +203,7 @@ class PromptPostProcessorA1111Script(scripts.Script):
         options = {
             "debug_level": getattr(opts, "ppp_gen_debug_level", DEBUG_LEVEL.none.value),
             "pony_substrings": getattr(opts, "ppp_gen_ponysubstrings", PromptPostProcessor.DEFAULT_PONY_SUBSTRINGS),
+            "illustrious_substrings": getattr(opts, "ppp_gen_illustrioussubstrings", PromptPostProcessor.DEFAULT_ILLUSTRIOUS_SUBSTRINGS),
             "process_wildcards": getattr(opts, "ppp_wil_processwildcards", True),
             "if_wildcards": getattr(opts, "ppp_wil_ifwildcards", PromptPostProcessor.IFWILDCARDS_CHOICES.ignore.value),
             "choice_separator": getattr(opts, "ppp_wil_choice_separator", PromptPostProcessor.DEFAULT_CHOICE_SEPARATOR),
@@ -383,6 +384,14 @@ def on_ui_settings():
         info=shared.OptionInfo(
             PromptPostProcessor.DEFAULT_PONY_SUBSTRINGS,
             label="Comma separated list of substrings to look for in the model full filename to flag it as Pony (case insensitive)",
+            section=section,
+        ),
+    )
+    shared.opts.add_option(
+        key="ppp_gen_illustrioussubstrings",
+        info=shared.OptionInfo(
+            PromptPostProcessor.DEFAULT_ILLUSTRIOUS_SUBSTRINGS,
+            label="Comma separated list of substrings to look for in the model full filename to flag it as Illustrious (case insensitive)",
             section=section,
         ),
     )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -30,6 +30,7 @@ class TestPromptPostProcessor(unittest.TestCase):
         self.__defopts = {
             "debug_level": DEBUG_LEVEL.full.value,
             "pony_substrings": PromptPostProcessor.DEFAULT_PONY_SUBSTRINGS,
+            "illustrious_substrings": PromptPostProcessor.DEFAULT_ILLUSTRIOUS_SUBSTRINGS,
             "process_wildcards": True,
             "if_wildcards": PromptPostProcessor.IFWILDCARDS_CHOICES.ignore.value,
             "choice_separator": ", ",


### PR DESCRIPTION
# Pull Request

## Description

System variables, substrings, and options added for Illustrious models. The syntax is identical to the pony tags.
I also added  _is_sdxl_no_pony_no_illustrious is true if a SDXL model is not pony and not illustrious.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules
- [x ] I have checked my code and corrected any misspellings
